### PR TITLE
Restart identity when truncating fixture db

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,7 +87,7 @@ class FixtureFactory
   def self.clear_db
     with_fixture_connection do
       %w(users comments groups roles roles_users documents uploaded_files).each do |table_name|
-        ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name}")
+        ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY")
       end
     end
   end


### PR DESCRIPTION
In order to try and stabilize test screenshots.